### PR TITLE
Implemented Random User / Random Activity API services

### DIFF
--- a/app/Exceptions/ApiException.php
+++ b/app/Exceptions/ApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Exceptions;
+
+class ApiException extends \Exception
+{
+}

--- a/app/Exceptions/RandomActivityException.php
+++ b/app/Exceptions/RandomActivityException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Exceptions;
+
+class RandomActivityException extends ApiException
+{
+}

--- a/app/Exceptions/RandomUserException.php
+++ b/app/Exceptions/RandomUserException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Exceptions;
+
+class RandomUserException extends ApiException
+{
+}

--- a/app/Http/Controllers/RandomUserController.php
+++ b/app/Http/Controllers/RandomUserController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Exceptions\ApiException;
+use App\Exceptions\RandomActivityException;
+use App\Exceptions\RandomUserException;
+use App\Services\RandomActivity\RandomActivityService;
+use App\Services\RandomUser\RandomUserService;
+use Illuminate\Http\JsonResponse;
+
+class RandomUserController extends Controller
+{
+    public function user(RandomUserService $randomUserService)
+    {
+        $randomUser = $randomUserService->getItem();
+
+        return new JsonResponse($randomUser->toArray());
+    }
+
+    public function users(RandomUserService $randomUserService, RandomActivityService $randomActivityService)
+    {
+        try {
+            $users = $randomUserService->getData();
+
+            return response()->xml([
+                'status' => 'success',
+                'user' => $users,
+            ]);
+        } catch (RandomUserException) {
+            try {
+                $activity = $randomActivityService->getData();
+
+                return response()->xml([
+                    'status' => 'success',
+                    'activity' => $activity,
+                ]);
+            } catch (RandomActivityException $e) {
+                return $this->error($e);
+            }
+        } catch (ApiException $e) {
+            return $this->error($e);
+        }
+    }
+
+    private function error(\Exception $e)
+    {
+        return response()->xml([
+            'status' => 'error',
+            'message' => $e->getMessage(),
+        ]);
+    }
+}

--- a/app/Http/Entities/Activity.php
+++ b/app/Http/Entities/Activity.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Http\Entities;
+
+class Activity
+{
+    private string $activity = '';
+
+    private string $type = '';
+
+    private int $participants = 0;
+
+    private int $price = 0;
+
+    private string $link = '';
+
+    private string $key = '';
+
+    private int $accessibility = 0;
+
+    public function getActivity(): string
+    {
+        return $this->activity;
+    }
+
+    public function setActivity(string $activity): self
+    {
+        $this->activity = $activity;
+
+        return $this;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getParticipants(): int
+    {
+        return $this->participants;
+    }
+
+    public function setParticipants(int $participants): self
+    {
+        $this->participants = $participants;
+
+        return $this;
+    }
+
+    public function getPrice(): int
+    {
+        return $this->price;
+    }
+
+    public function setPrice(int $price): self
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+
+    public function getLink(): string
+    {
+        return $this->link;
+    }
+
+    public function setLink(string $link): self
+    {
+        $this->link = $link;
+
+        return $this;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function setKey(string $key): self
+    {
+        $this->key = $key;
+
+        return $this;
+    }
+
+    public function getAccessibility(): int
+    {
+        return $this->accessibility;
+    }
+
+    public function setAccessibility(int $accessibility): self
+    {
+        $this->accessibility = $accessibility;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'activity' => $this->activity,
+            'type' => $this->type,
+            'participants' => $this->participants,
+            'price' => $this->price,
+            'link' => $this->link,
+            'key' => $this->key,
+            'accessibility' => $this->accessibility,
+        ];
+    }
+}

--- a/app/Http/Entities/User.php
+++ b/app/Http/Entities/User.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Entities;
+
+class User
+{
+    private string $title = '';
+
+    private string $firstName = '';
+
+    private string $lastName = '';
+
+    private string $fullName = '';
+
+    private string $phone = '';
+
+    private string $email = '';
+
+    private string $country = '';
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(string $firstName): self
+    {
+        $this->firstName = $firstName;
+
+        return $this;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(string $lastName): self
+    {
+        $this->lastName = $lastName;
+
+        return $this;
+    }
+
+    public function getFullName(): string
+    {
+        return $this->fullName;
+    }
+
+    public function setFullName(string $fullName): self
+    {
+        $this->fullName = $fullName;
+
+        return $this;
+    }
+
+    public function getPhone(): string
+    {
+        return $this->phone;
+    }
+
+    public function setPhone(string $phone): self
+    {
+        $this->phone = $phone;
+
+        return $this;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    public function getCountry(): string
+    {
+        return $this->country;
+    }
+
+    public function setCountry(string $country): self
+    {
+        $this->country = $country;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'full_name' => sprintf('%s %s %s', $this->title, $this->firstName, $this->lastName),
+            'phone' => $this->phone,
+            'email' => $this->email,
+            'country' => $this->country,
+        ];
+    }
+}

--- a/app/Services/AbstractBaseApiService.php
+++ b/app/Services/AbstractBaseApiService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Collection;
+
+abstract class AbstractBaseApiService
+{
+
+    /**
+     * @throws \App\Exceptions\ApiException
+     */
+    public function getData(): array
+    {
+        $collection = new Collection();
+        for ($i = 0; $i < 10; $i++) {
+            $collection->push($this->getItem());
+        }
+
+        return $this
+            ->sortItems($collection)
+            ->toArray();
+    }
+}

--- a/app/Services/ApiServiceInterface.php
+++ b/app/Services/ApiServiceInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Collection;
+
+interface ApiServiceInterface
+{
+    public function getData(): array;
+
+    public function getItem();
+
+    public function sortItems(Collection $collection): Collection;
+}

--- a/app/Services/RandomActivity/API/RandomActivitiesApiClient.php
+++ b/app/Services/RandomActivity/API/RandomActivitiesApiClient.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Services\RandomActivity\API;
+
+use Illuminate\Support\Facades\Http;
+
+class RandomActivitiesApiClient
+{
+    const BASE_API_URL = 'https://www.boredapi.com/api/activity';
+
+    /**
+     * @return array|mixed
+     */
+    public function getRandomActivity(): mixed
+    {
+        return Http::get(self::BASE_API_URL)->json();
+    }
+}

--- a/app/Services/RandomActivity/RandomActivityService.php
+++ b/app/Services/RandomActivity/RandomActivityService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services\RandomActivity;
+
+use App\Exceptions\RandomActivityException;
+use App\Http\Entities\Activity;
+use App\Services\AbstractBaseApiService;
+use App\Services\ApiServiceInterface;
+use App\Services\RandomActivity\API\RandomActivitiesApiClient;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Collection;
+
+class RandomActivityService extends AbstractBaseApiService implements ApiServiceInterface
+{
+    public function __construct(private readonly RandomActivitiesApiClient $client)
+    {
+    }
+
+    public function getItem()
+    {
+        try {
+            $response = $this->client->getRandomActivity();
+            if (empty($response) || isset($response['error'])) {
+                throw new RandomActivityException($response['error']);
+            }
+
+            $activity = new Activity();
+            $activity
+                ->setActivity($response['activity'] ?? '')
+                ->setType($response['type'] ?? '')
+                ->setParticipants($response['participants'] ?? 0)
+                ->setPrice($response['price'] ?? 0)
+                ->setLink($response['link'] ?? '')
+                ->setKey($response['key'] ?? '')
+                ->setAccessibility($response['accessibility'] ?? 0);
+
+            return $activity;
+        } catch (ConnectionException $exception) {
+            throw new RandomActivityException('Could not connect to Random Activity API.', 500, $exception);
+        }
+    }
+
+    public function sortItems(Collection $collection): Collection
+    {
+        return $collection
+            ->sortBy('type')
+            ->map(fn (Activity $activity) => $activity->toArray());
+    }
+}

--- a/app/Services/RandomUser/API/RandomUserApiClient.php
+++ b/app/Services/RandomUser/API/RandomUserApiClient.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Services\RandomUser\API;
+
+use Illuminate\Support\Facades\Http;
+
+class RandomUserApiClient
+{
+    const BASE_API_URL = 'https://randomuser.me/api/';
+
+    /**
+     * @return array|mixed
+     */
+    public function getRandomUser(): mixed
+    {
+        return Http::get(self::BASE_API_URL)->json();
+    }
+}

--- a/app/Services/RandomUser/RandomUserService.php
+++ b/app/Services/RandomUser/RandomUserService.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Services\RandomUser;
+
+use App\Exceptions\RandomUserException;
+use App\Http\Entities\User;
+use App\Services\AbstractBaseApiService;
+use App\Services\ApiServiceInterface;
+use App\Services\RandomUser\API\RandomUserApiClient;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Collection;
+
+class RandomUserService extends AbstractBaseApiService implements ApiServiceInterface
+{
+    public function __construct(private readonly RandomUserApiClient $client)
+    {
+    }
+
+    /**
+     * @return \App\Http\Entities\User
+     * @throws \App\Exceptions\RandomUserException
+     */
+    public function getItem(): User
+    {
+        try {
+            $response = $this->client->getRandomUser();
+
+            $data = $response['results'][0] ?? [];
+            if (empty($data)) {
+                throw new RandomUserException('There is no data in response.');
+            }
+
+            $name = $data['name'];
+
+            $user = new User();
+            $user
+                ->setTitle($name['title'])
+                ->setFirstName($name['first'])
+                ->setLastName($name['last'])
+                ->setPhone($data['phone'])
+                ->setEmail($data['email'])
+                ->setCountry($data['location']['country']);
+
+            return $user;
+        } catch (ConnectionException $exception) {
+            throw new RandomUserException('Could not connect to Random User API.', 500, $exception);
+        }
+    }
+
+    public function sortItems(Collection $collection): Collection
+    {
+        return $collection
+            ->sortByDesc([
+                fn (User $a, User $b) => $b->getLastName() <=> $a->getLastName(),
+            ])
+            ->map(fn (User $user) => $user->toArray());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.2",
-        "laravel/tinker": "^2.8"
+        "laravel/tinker": "^2.8",
+        "mtownsend/response-xml": "^2.2"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa322c53454393ed775cfe4807d54a50",
+    "content-hash": "f2236ea599028a65810c7b6a2fa768d4",
     "packages": [
         {
             "name": "brick/math",
@@ -1918,6 +1918,69 @@
             "time": "2023-06-21T08:46:11+00:00"
         },
         {
+            "name": "mtownsend/response-xml",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mtownsend5512/response-xml.git",
+                "reference": "211cadff222014e2ee0a35e304b9ed76d183fd98"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mtownsend5512/response-xml/zipball/211cadff222014e2ee0a35e304b9ed76d183fd98",
+                "reference": "211cadff222014e2ee0a35e304b9ed76d183fd98",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/container": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "illuminate/http": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "illuminate/routing": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "php": "~7.0|~8.0",
+                "spatie/array-to-xml": "^3.1"
+            },
+            "require-dev": {
+                "laravel/framework": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "phpunit/phpunit": "^6.4|^8.5|^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Mtownsend\\ResponseXml\\Providers\\ResponseXmlServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mtownsend\\ResponseXml\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Townsend",
+                    "email": "mtownsend5512@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The missing XML support for Laravel's Response class.",
+            "keywords": [
+                "api",
+                "laravel",
+                "response",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/mtownsend5512/response-xml/issues",
+                "source": "https://github.com/mtownsend5512/response-xml/tree/2.2.0"
+            },
+            "time": "2023-02-02T14:35:03+00:00"
+        },
+        {
             "name": "nesbot/carbon",
             "version": "2.71.0",
             "source": {
@@ -3104,6 +3167,69 @@
                 }
             ],
             "time": "2023-04-15T23:01:58+00:00"
+        },
+        {
+            "name": "spatie/array-to-xml",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/array-to-xml.git",
+                "reference": "f9ab39c808500c347d5a8b6b13310bd5221e39e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/f9ab39c808500c347d5a8b6b13310bd5221e39e7",
+                "reference": "f9ab39c808500c347d5a8b6b13310bd5221e39e7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.2",
+                "pestphp/pest": "^1.21",
+                "spatie/pest-plugin-snapshots": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ArrayToXml\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://freek.dev",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Convert an array to xml",
+            "homepage": "https://github.com/spatie/array-to-xml",
+            "keywords": [
+                "array",
+                "convert",
+                "xml"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/array-to-xml/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-07-19T18:30:26+00:00"
         },
         {
             "name": "symfony/console",
@@ -8075,5 +8201,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,3 +17,7 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::get('/user', [\App\Http\Controllers\RandomUserController::class, 'user']);
+
+Route::get('/users', [\App\Http\Controllers\RandomUserController::class, 'users']);


### PR DESCRIPTION
In this PR I Implemented Random User / Random Activity API services.
I hope that I've got the requirements correct:
 - in case Random User API service is not reachable - I fetch data from Random Activity API, 
 - if Random Activity API is not reachable - I show an error message and status 'error'.

API endpoint: `/api/users`

Unfortunately, I couldn't make it in time to add PHPUnit tests.

As a bonus - the application is Dockerized!
To run it just run a command after cloning the Repo:
```
cd random-user && ./vendor/bin/sail up
```